### PR TITLE
UX: all category styles need usable active state

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -35,10 +35,12 @@
         padding-right: 0.5em;
         &:hover,
         &:focus {
+          color: var(--tertiary-high);
           background: transparent !important;
-          border-bottom: 2px solid var(--tertiary-medium);
+          border-bottom: 2px solid var(--tertiary-high);
         }
         &.active {
+          color: var(--tertiary);
           background: transparent;
           border-bottom: 2px solid var(--tertiary);
         }


### PR DESCRIPTION
The `none` category badge style was invisible when active: 

Before:
![Screenshot 2023-05-01 at 12 13 56 PM](https://user-images.githubusercontent.com/1681963/235485523-e3f6d53a-3720-40c9-a0e8-174d30614fa6.png)


After:
![Screenshot 2023-05-01 at 12 13 37 PM](https://user-images.githubusercontent.com/1681963/235485529-76a627ee-5506-4343-943e-60d17a59b7e7.png)
