### PR TITLE
FIX: only hide category dropdown, not messages

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -105,16 +105,18 @@
   }
 }
 
-@if $hide-category-dropdown == "true" {
-  .category-breadcrumb {
-    li:first-child {
-      display: none;
+.list-controls {
+  @if $hide-category-dropdown == "true" {
+    .category-breadcrumb {
+      li:first-child {
+        display: none;
+      }
     }
   }
-}
 
-@if $hide-all-breadcrumb-nav == "true" {
-  .navigation-container {
-    display: none;
+  @if $hide-all-breadcrumb-nav == "true" {
+    .navigation-container {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
These settings were too broad and were hiding the dropdown menu on /u/my/messages as well