### PR TITLE
FIX: update to support 3 levels of categories

### DIFF
--- a/javascripts/discourse/components/custom-categories-navbar.js
+++ b/javascripts/discourse/components/custom-categories-navbar.js
@@ -19,7 +19,7 @@ export default class CustomCategoriesNavbar extends Component {
     if (currentRoute && currentRoute.attributes?.category) {
       let activeCategory = currentRoute.attributes.category;
 
-      if (activeCategory.parentCategory) {
+      while (activeCategory.parentCategory) {
         activeCategory = activeCategory.parentCategory;
       }
 


### PR DESCRIPTION
This was attempting to select the wrong category when 3-levels of categories were enabled, it will now find the original parent reliably. 